### PR TITLE
added vars form mfa and aws regioning, clarified doc, updated tf provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [![Slalom][logo]](https://slalom.com)
 
 # terraform-aws-statebucket [![Build Status](https://travis-ci.com/JamesWoolfenden/terraform-aws-statebucket.svg?branch=master)](https://travis-ci.com/JamesWoolfenden/terraform-aws-statebucket) [![Latest Release](https://img.shields.io/github/release/JamesWoolfenden/terraform-aws-statebucket.svg)](https://github.com/JamesWoolfenden/terraform-aws-statebucket/releases/latest)
@@ -9,15 +8,39 @@ Terraform module to provision a secure terraform state bucket for team use of IA
 
 It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
+## Versions
+
+| Terraform Version | Statebucket Release |
+| :---------------: | :-----------------: |
+|      0.12.x       |        0.3.0        |
+|      0.11.x       |       0.2.25        |
+
 ## Usage
 
 Include this repository as a module in your existing Terraform code:
 
-```terraform
+```hcl
 module statebucket {
   source      = "JamesWoolfenden/statebucket/aws"
-  version     = "0.2.25"
+  version     = "0.3.0"
   common_tags = var.common_tags
+}
+```
+
+Setup as per example.
+
+Use the generated `remote_state.tf` and change the bucket key for each subsequent service as required
+
+```hcl
+terraform {
+...
+
+  backend "s3" {
+    ...
+
+    key = "<your-service>/<provider-service>/terraform.tfstate"
+    ...
+  }
 }
 ```
 
@@ -32,7 +55,7 @@ The module and example solves the issue of creating a state bucket in Terraform 
 
 The Makefile in folder _examples\examplesA_ has a number of tasks, one specifically to create the initial bucket:
 
-```make
+```sh
 make first
 ```
 
@@ -40,7 +63,7 @@ This makes the lock DB table, the state (S3) bucket, fills out and creates the r
 
 On the second and subsequent runs you use:
 
-```make
+```sh
 make build
 ```
 
@@ -52,27 +75,30 @@ The module also uses a tagging based on the map variable common_tags scheme.
 
 This Scheme here uses as a minimum (in your terraform.tfvars):
 
-```HCL
+```hcl
 common_tags = {
-Application = "terraform"
-Module = "statebucket"
-Environment = "develop"
+  application = "terraform"
+  module = "statebucket"
+  environment = "develop"
 }
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| common\_tags | This is a map type for applying tags on resources | map | n/a | yes |
+| Name          | Description                                            |  Type   |  Default  | Required |
+| ------------- | ------------------------------------------------------ | :-----: | :-------: | :------: |
+| common_tags   | This is a map type for applying tags on resources      |   map   |    n/a    |   yes    |
+| s3_mfa_delete | Allow for disabling mfa deletion                       | boolean |   true    |    no    |
+| aws_region    | This is the default AWS region for the S3 and dynamoDB | string  | eu-west-1 |    no    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| bucket\_domain\_name | The FQDN for the bucket |
-| statebucket | The state bucket details |
+| Name               | Description              |
+| ------------------ | ------------------------ |
+| bucket_domain_name | The FQDN for the bucket  |
+| statebucket        | The state bucket details |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
@@ -105,35 +131,33 @@ Copyright © 2019-2019 [Slalom, LLC](https://slalom.com)
 See [LICENSE](LICENSE) for full details.
 
 Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
+or more contributor license agreements. See the NOTICE file
 distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
+regarding copyright ownership. The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
+with the License. You may obtain a copy of the License at
 
 <https://www.apache.org/licenses/LICENSE-2.0>
 
 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
+KIND, either express or implied. See the License for the
 specific language governing permissions and limitations
 under the License.
 
 ### Contributors
 
-  [![James Woolfenden][jameswoolfenden_avatar]][jameswoolfenden_homepage]<br/>[James Woolfenden][jameswoolfenden_homepage]
+[![James Woolfenden][jameswoolfenden_avatar]][jameswoolfenden_homepage]<br/>[James Woolfenden][jameswoolfenden_homepage]
 
-  [jameswoolfenden_homepage]: https://github.com/jameswoolfenden
-  [jameswoolfenden_avatar]: https://github.com/jameswoolfenden.png?size=150
-
+[jameswoolfenden_homepage]: https://github.com/jameswoolfenden
+[jameswoolfenden_avatar]: https://github.com/jameswoolfenden.png?size=150
 [logo]: https://gist.githubusercontent.com/JamesWoolfenden/5c457434351e9fe732ca22b78fdd7d5e/raw/15933294ae2b00f5dba6557d2be88f4b4da21201/slalom-logo.png
 [website]: https://slalom.com
 [github]: https://github.com/jameswoolfenden
 [linkedin]: https://www.linkedin.com/company/slalom-consulting/
 [twitter]: https://twitter.com/Slalom
-
 [share_twitter]: https://twitter.com/intent/tweet/?text=terraform-aws-statebucket&url=https://github.com/JamesWoolfenden/terraform-aws-statebucket
 [share_linkedin]: https://www.linkedin.com/shareArticle?mini=true&title=terraform-aws-statebucket&url=https://github.com/JamesWoolfenden/terraform-aws-statebucket
 [share_reddit]: https://reddit.com/submit/?url=https://github.com/JamesWoolfenden/terraform-aws-statebucket

--- a/aws_s3_bucket.state_bucket.tf
+++ b/aws_s3_bucket.state_bucket.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "statebucket" {
 
   versioning {
     enabled    = true
-    mfa_delete = true
+    mfa_delete = s3_mfa_delete
   }
 
   tags = var.common_tags

--- a/aws_s3_bucket.state_bucket.tf
+++ b/aws_s3_bucket.state_bucket.tf
@@ -5,7 +5,7 @@ resource "aws_s3_bucket" "statebucket" {
 
   versioning {
     enabled    = true
-    mfa_delete = s3_mfa_delete
+    mfa_delete = var.s3_mfa_delete
   }
 
   tags = var.common_tags

--- a/example/exampleA/provider.aws.tf
+++ b/example/exampleA/provider.aws.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   version = "2.39"
-  region  = "eu-west-1"
+  region  = var.aws_region
 }
 
 provider "template" {

--- a/example/exampleA/variables.tf
+++ b/example/exampleA/variables.tf
@@ -2,3 +2,13 @@ variable "common_tags" {
   description = "This is a map type for applying tags on resources"
   type        = map
 }
+
+variable "s3_mfa_delete" {
+  description = "Allow for disabling mfa deletion"
+  default = true
+}
+
+variable "aws_region" {
+  description = "This is the default AWS region"
+  default = "eu-west-1"
+}

--- a/remote_state.tf.template
+++ b/remote_state.tf.template
@@ -1,8 +1,9 @@
 terraform {
-  # fix the provider version
-  version = "1"
+  # Fix the provider version
+  required_version = "~> 0.12.6"
 
-  #add role_arn to use assumed roles to access the bucket
+
+  # Add role_arn to use assumed roles to access the bucket
   backend "s3" {
     encrypt        = true
     bucket         = "${account_number}-terraform-state"

--- a/variables.tf
+++ b/variables.tf
@@ -2,3 +2,13 @@ variable "common_tags" {
   description = "This is a map type for applying tags on resources"
   type        = map
 }
+
+variable "s3_mfa_delete" {
+  description = "Allow for disabling mfa deletion"
+  default = true
+}
+
+variable "aws_region" {
+  description = "This is the default AWS region"
+  default = "eu-west-1"
+}


### PR DESCRIPTION
Hi @JamesWoolfenden - hope you're well 😄 

Clearly I've got nothing better to do on holiday...

I've had a few challenges in getting this up and running with the latest version of TF. I've put the changes in a PR and was hoping they'd help with maintaining the package. Sorry if I've missed any TF conventions or if values would've overridden and I've missed something.

**Proposed Changes**

1. Clarification re `remote_state.tf` key and how to continue with application-service-per-folder iac. I could re-structure to use "${var.common_tags.application}/${var.common_tags.module}/terraform.tfstate" or document it similar?
1. Corrected the casing on `common_tags` in the readme.
1. Needed to do an update for 0.12.x tf syntax changes - no interpolation, `version` => `required_version`, etc. Do we/can we lock down the tf version anywhere?
1. AWS Provider region was set to `eu-west-1`, have abstracted to optional variable.
1. Optional s3 mfa deletion. This has been impossible to coordinate and get working with a remote team. I realise this may very well just be my use case though so totally open to removing it from the PR.

Also I'm not sure how to do a specific version bump in travis? I was thinking 0.3.0 (semver-minor) as it's a breaking change but not to the module API.

Hopefully this makes the cut 🙌Thanks!